### PR TITLE
fix: Make cover_image nullable on update

### DIFF
--- a/app/Http/Controllers/MyStoryController.php
+++ b/app/Http/Controllers/MyStoryController.php
@@ -32,14 +32,18 @@ class MyStoryController extends Controller
             'title' => 'required|string',
             'content' => 'required|string',
             'genre_id' => 'required|integer|exists:genres,id',
-            'cover_image' => 'required|file|mimes:jpg,jpeg,png'
+            'cover_image' => 'nullable|file|mimes:jpg,jpeg,png'
         ]);
 
         try {
-            Storage::disk('public')->delete($story->cover_image);
+            if ($request->hasFile('cover_image')) {
+                Storage::disk('public')->delete($story->cover_image);
 
-            $imagePath = $request->file('cover_image')->store('stories', 'public');
-            $validated['cover_image'] = $imagePath;
+                $imagePath = $request->file('cover_image')->store('stories', 'public');
+                $validated['cover_image'] = $imagePath;
+            } else {
+                $validated['cover_image'] = $story->cover_image;
+            }
 
             $story->update([
                 'title' => $validated['title'],

--- a/resources/views/mystories/edit.blade.php
+++ b/resources/views/mystories/edit.blade.php
@@ -62,14 +62,12 @@
           @enderror
         </div>
         <div class="flex gap-2">
-          <a href="{{ route('profile.my-stories.index') }}"
+          <a href="{{ route('mystories.index') }}"
             class="h-10 bg-gray-500 hover:bg-gray-600 transition-colors p-2 px-3 rounded-xs text-white font-medium shadow-sm">Cancel</a>
 
-          <a href="{{ route('profile.my-stories.index') }}"
+          <button
             class="h-10 bg-orange-500 hover:bg-orange-600
-            transition-colors p-2 px-3 rounded-xs text-white font-medium shadow-sm">Update</a>
-          <a
-            class="h-10 bg-red-500 hover:bg-red-600 transition-colors p-2 px-3 rounded-xs text-white font-medium shadow-sm">Delete</a>
+            transition-colors p-2 px-3 rounded-xs text-white font-medium shadow-sm">Update</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
Make cover_image field nullable during update to allow retaining existing image if no new file is uploaded